### PR TITLE
Add canonical tags to all public pages

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -65,7 +65,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 ## SEO
 
 - [ ] **19. Add `sitemap.xml` and `robots.txt`** (~3 hrs)
-- [ ] **20. Add canonical tags to all pages** (~1 hr) — Route `head()` functions
+- [x] **20. Add canonical tags to all pages** (~1 hr) — Route `head()` functions
 - [ ] **21. Add structured data (JSON-LD)** (~3 hrs) — `src/routes/images/$id.tsx`, `src/routes/collections/$id.tsx`
 - [ ] **22. Add OG tags to collection pages** (~1 hr) — `src/routes/collection/$id.tsx`
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = 'https://pictures.loowis.co.uk'

--- a/src/routes/all-images.tsx
+++ b/src/routes/all-images.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import Layout from '~/components/Layout/Layout'
 import ImageModal from '~/components/ImageModal/ImageModal'
 import SortingButtons from '~/components/SortingButtons/SortingButtons'
@@ -12,8 +13,9 @@ export const Route = createFileRoute('/all-images')({
     loaderDeps: ({ search }) => search,
     loader: ({ deps: { page, sort, filter } }) =>
         getAllImages({ data: { page, sort, filter } }),
-    head: () => ({
+    head: ({ match }) => ({
         meta: [{ title: 'All Images | Loowis Photography' }],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: AllImages,
 })

--- a/src/routes/collection/$id.tsx
+++ b/src/routes/collection/$id.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import Layout from '~/components/Layout/Layout'
 import ImageModal from '~/components/ImageModal/ImageModal'
 import SortingButtons from '~/components/SortingButtons/SortingButtons'
@@ -17,12 +18,13 @@ export const Route = createFileRoute('/collection/$id')({
         if (!result) throw notFound()
         return result
     },
-    head: ({ loaderData }) => ({
+    head: ({ loaderData, match }) => ({
         meta: [
             {
                 title: `${loaderData?.collection?.collection_name ?? 'Collection'} | Loowis Photography`,
             },
         ],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: Collection,
 })

--- a/src/routes/collections.tsx
+++ b/src/routes/collections.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import Layout from '~/components/Layout/Layout'
 import CollectionPreview from '~/components/CollectionPreview/CollectionPreview'
 import { getAllCollections } from '~/lib/server/collections'
@@ -6,8 +7,9 @@ import styles from '~/styles/pages/collections.module.css'
 
 export const Route = createFileRoute('/collections')({
     loader: () => getAllCollections(),
-    head: () => ({
+    head: ({ match }) => ({
         meta: [{ title: 'Collections | Loowis Photography' }],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: Collections,
 })

--- a/src/routes/image-map.tsx
+++ b/src/routes/image-map.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import { useEffect } from 'react'
 import Layout from '~/components/Layout/Layout'
 import { getImagesForMap } from '~/lib/server/images'
@@ -6,8 +7,9 @@ import styles from '~/styles/pages/image-map.module.css'
 
 export const Route = createFileRoute('/image-map')({
     loader: () => getImagesForMap(),
-    head: () => ({
+    head: ({ match }) => ({
         meta: [{ title: 'Image Map | Lewis Inches - Photography' }],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: ImageMap,
 })

--- a/src/routes/images/$id.tsx
+++ b/src/routes/images/$id.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, notFound } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import Layout from '~/components/Layout/Layout'
 import ImagePage from '~/components/ImagePage/ImagePage'
 import { getImageById } from '~/lib/server/images'
@@ -10,7 +11,7 @@ export const Route = createFileRoute('/images/$id')({
         if (!image) throw notFound()
         return image
     },
-    head: ({ loaderData }) => ({
+    head: ({ loaderData, match }) => ({
         meta: [
             {
                 title: `${loaderData?.title ?? 'Image'} | Loowis Photography`,
@@ -24,9 +25,10 @@ export const Route = createFileRoute('/images/$id')({
                 content: loaderData?.description || 'Photography by Loowis',
             },
             { name: 'og:image', content: loaderData?.url ?? '' },
-            { name: 'og:url', content: 'pictures.loowis.co.uk' },
+            { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
             { name: 'og:type', content: 'website' },
         ],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: Photo,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import { useState } from 'react'
 import Layout from '~/components/Layout/Layout'
 import ImageModal from '~/components/ImageModal/ImageModal'
@@ -7,8 +8,9 @@ import styles from '~/styles/pages/index.module.css'
 
 export const Route = createFileRoute('/')({
     loader: () => getFeaturedImages(),
-    head: () => ({
+    head: ({ match }) => ({
         meta: [{ title: 'Loowis Photography' }],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: Home,
 })

--- a/src/routes/search/$query.tsx
+++ b/src/routes/search/$query.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { BASE_URL } from '~/lib/constants'
 import Layout from '~/components/Layout/Layout'
 import ImageModal from '~/components/ImageModal/ImageModal'
 import { searchImages } from '~/lib/server/search'
@@ -6,8 +7,9 @@ import styles from '~/styles/pages/search.module.css'
 
 export const Route = createFileRoute('/search/$query')({
     loader: ({ params: { query } }) => searchImages({ data: query }),
-    head: () => ({
+    head: ({ match }) => ({
         meta: [{ title: 'Search Results | Lewis Inches - Photography' }],
+        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),
     component: Search,
 })


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` to all 7 public routes using `match.pathname` from TanStack Router's `head()` context
- Create shared `BASE_URL` constant in `src/lib/constants.ts`
- Fix broken `og:url` on `/images/$id` (was missing protocol and path)

## Test plan
- [ ] `npm run build` passes
- [ ] View page source on dev server — confirm `<link rel="canonical" href="https://pictures.loowis.co.uk/...">` renders on each public page
- [ ] Check dynamic routes (`/images/:id`, `/collection/:id`) have correct canonical URLs with resolved params
- [ ] Check paginated route `/all-images?page=2` has canonical pointing to `/all-images` (no query params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)