### PR TITLE
Add OG tags to collection pages

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -67,7 +67,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 - [ ] **19. Add `sitemap.xml` and `robots.txt`** (~3 hrs)
 - [x] **20. Add canonical tags to all pages** (~1 hr) — Route `head()` functions
 - [ ] **21. Add structured data (JSON-LD)** (~3 hrs) — `src/routes/images/$id.tsx`, `src/routes/collections/$id.tsx`
-- [ ] **22. Add OG tags to collection pages** (~1 hr) — `src/routes/collection/$id.tsx`
+- [x] **22. Add OG tags to collection pages** (~1 hr) — `src/routes/collection/$id.tsx`
 
 ---
 

--- a/src/routes/collection/$id.tsx
+++ b/src/routes/collection/$id.tsx
@@ -23,6 +23,22 @@ export const Route = createFileRoute('/collection/$id')({
             {
                 title: `${loaderData?.collection?.collection_name ?? 'Collection'} | Loowis Photography`,
             },
+            {
+                name: 'og:title',
+                content: `${loaderData?.collection?.collection_name ?? 'Collection'} | Loowis Photography`,
+            },
+            {
+                name: 'og:description',
+                content:
+                    loaderData?.collection?.collection_description ||
+                    'Photography by Loowis',
+            },
+            {
+                name: 'og:image',
+                content: loaderData?.collection?.cover_url ?? '',
+            },
+            { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
+            { name: 'og:type', content: 'website' },
         ],
         links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
     }),


### PR DESCRIPTION
## Summary
- Add `og:title`, `og:description`, `og:image`, `og:url`, and `og:type` meta tags to `/collection/$id`
- Uses collection name, description, and cover image from loader data
- Matches the existing pattern on `/images/$id`

## Test plan
- [ ] `npm run build` passes
- [ ] Share a collection URL on social media / paste into OG preview tool — confirm title, description, and cover image appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)