### PR TITLE
Add sitemap.xml and robots.txt

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -64,7 +64,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 
 ## SEO
 
-- [ ] **19. Add `sitemap.xml` and `robots.txt`** (~3 hrs)
+- [x] **19. Add `sitemap.xml` and `robots.txt`** (~3 hrs) — `public/robots.txt`, `src/routes/api/sitemap.ts`
 - [x] **20. Add canonical tags to all pages** (~1 hr) — Route `head()` functions
 - [ ] **21. Add structured data (JSON-LD)** (~3 hrs) — `src/routes/images/$id.tsx`, `src/routes/collections/$id.tsx`
 - [x] **22. Add OG tags to collection pages** (~1 hr) — `src/routes/collection/$id.tsx`

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Allow: /api/sitemap
+Disallow: /admin/
+Disallow: /api/
+
+Sitemap: https://pictures.loowis.co.uk/api/sitemap

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as SearchQueryRouteImport } from './routes/search/$query'
 import { Route as ImagesIdRouteImport } from './routes/images/$id'
 import { Route as CollectionIdRouteImport } from './routes/collection/$id'
+import { Route as ApiSitemapRouteImport } from './routes/api/sitemap'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AdminNewImageRouteImport } from './routes/admin/new/image'
 import { Route as AdminNewCollectionRouteImport } from './routes/admin/new/collection'
@@ -76,6 +77,11 @@ const CollectionIdRoute = CollectionIdRouteImport.update({
   path: '/collection/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSitemapRoute = ApiSitemapRouteImport.update({
+  id: '/api/sitemap',
+  path: '/api/sitemap',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
@@ -115,6 +121,7 @@ export interface FileRoutesByFullPath {
   '/all-images': typeof AllImagesRoute
   '/collections': typeof CollectionsRoute
   '/image-map': typeof ImageMapRoute
+  '/api/sitemap': typeof ApiSitemapRoute
   '/collection/$id': typeof CollectionIdRoute
   '/images/$id': typeof ImagesIdRoute
   '/search/$query': typeof SearchQueryRoute
@@ -132,6 +139,7 @@ export interface FileRoutesByTo {
   '/all-images': typeof AllImagesRoute
   '/collections': typeof CollectionsRoute
   '/image-map': typeof ImageMapRoute
+  '/api/sitemap': typeof ApiSitemapRoute
   '/collection/$id': typeof CollectionIdRoute
   '/images/$id': typeof ImagesIdRoute
   '/search/$query': typeof SearchQueryRoute
@@ -151,6 +159,7 @@ export interface FileRoutesById {
   '/all-images': typeof AllImagesRoute
   '/collections': typeof CollectionsRoute
   '/image-map': typeof ImageMapRoute
+  '/api/sitemap': typeof ApiSitemapRoute
   '/collection/$id': typeof CollectionIdRoute
   '/images/$id': typeof ImagesIdRoute
   '/search/$query': typeof SearchQueryRoute
@@ -171,6 +180,7 @@ export interface FileRouteTypes {
     | '/all-images'
     | '/collections'
     | '/image-map'
+    | '/api/sitemap'
     | '/collection/$id'
     | '/images/$id'
     | '/search/$query'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/all-images'
     | '/collections'
     | '/image-map'
+    | '/api/sitemap'
     | '/collection/$id'
     | '/images/$id'
     | '/search/$query'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/all-images'
     | '/collections'
     | '/image-map'
+    | '/api/sitemap'
     | '/collection/$id'
     | '/images/$id'
     | '/search/$query'
@@ -225,6 +237,7 @@ export interface RootRouteChildren {
   AllImagesRoute: typeof AllImagesRoute
   CollectionsRoute: typeof CollectionsRoute
   ImageMapRoute: typeof ImageMapRoute
+  ApiSitemapRoute: typeof ApiSitemapRoute
   CollectionIdRoute: typeof CollectionIdRoute
   ImagesIdRoute: typeof ImagesIdRoute
   SearchQueryRoute: typeof SearchQueryRoute
@@ -303,6 +316,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CollectionIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/sitemap': {
+      id: '/api/sitemap'
+      path: '/api/sitemap'
+      fullPath: '/api/sitemap'
+      preLoaderRoute: typeof ApiSitemapRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/auth/$': {
       id: '/api/auth/$'
       path: '/api/auth/$'
@@ -377,6 +397,7 @@ const rootRouteChildren: RootRouteChildren = {
   AllImagesRoute: AllImagesRoute,
   CollectionsRoute: CollectionsRoute,
   ImageMapRoute: ImageMapRoute,
+  ApiSitemapRoute: ApiSitemapRoute,
   CollectionIdRoute: CollectionIdRoute,
   ImagesIdRoute: ImagesIdRoute,
   SearchQueryRoute: SearchQueryRoute,

--- a/src/routes/api/sitemap.ts
+++ b/src/routes/api/sitemap.ts
@@ -1,0 +1,69 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getDb } from '~/lib/db'
+import { BASE_URL } from '~/lib/constants'
+
+interface SitemapRow {
+    id: number
+}
+
+export const Route = createFileRoute('/api/sitemap')({
+    server: {
+        handlers: {
+            GET: async () => {
+                const sql = getDb()
+
+                const collections =
+                    (await sql`SELECT collection_id AS id FROM collections ORDER BY collection_id`) as SitemapRow[]
+                const images =
+                    (await sql`SELECT image_id AS id FROM images WHERE visible = true ORDER BY image_id`) as SitemapRow[]
+
+                const today = new Date().toISOString().split('T')[0]
+
+                const staticUrls = [
+                    { path: '/', priority: '1.0' },
+                    { path: '/collections', priority: '0.8' },
+                    { path: '/all-images', priority: '0.8' },
+                    { path: '/image-map', priority: '0.7' },
+                ]
+
+                const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${staticUrls
+    .map(
+        ({ path, priority }) => `  <url>
+    <loc>${BASE_URL}${path}</loc>
+    <lastmod>${today}</lastmod>
+    <priority>${priority}</priority>
+  </url>`,
+    )
+    .join('\n')}
+${collections
+    .map(
+        (c) => `  <url>
+    <loc>${BASE_URL}/collection/${c.id}</loc>
+    <lastmod>${today}</lastmod>
+    <priority>0.7</priority>
+  </url>`,
+    )
+    .join('\n')}
+${images
+    .map(
+        (img) => `  <url>
+    <loc>${BASE_URL}/images/${img.id}</loc>
+    <lastmod>${today}</lastmod>
+    <priority>0.6</priority>
+  </url>`,
+    )
+    .join('\n')}
+</urlset>`
+
+                return new Response(xml, {
+                    headers: {
+                        'Content-Type': 'application/xml',
+                        'Cache-Control': 'public, max-age=3600',
+                    },
+                })
+            },
+        },
+    },
+})


### PR DESCRIPTION
## Summary
- Add dynamic sitemap at `/api/sitemap` that queries the database for all collections and visible images
- Add `robots.txt` that disallows `/admin/` and `/api/` (except the sitemap endpoint)
- Mark item #19 as done in IMPROVEMENTS.md

## Test plan
- [ ] Visit `/robots.txt` and verify it returns correct directives
- [ ] Visit `/api/sitemap` and verify it returns valid XML with static routes, collections, and images
- [ ] Verify build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)