### PR TITLE
Add ARIA roles and keyboard support to image modals

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -73,7 +73,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 
 ## Accessibility
 
-- [x] **23. Add ARIA roles to image modals** (~3 hrs) — `src/components/ImageModal/ModalContent/ModalContent.tsx`, `ImageModal.tsx`, `ImageModal.module.css`
+- [x] **23. Add ARIA roles to image modals** (~3 hrs) — `src/components/ImageModal/ModalContent/ModalContent.tsx`, `src/components/ImageModal/ImageModal.tsx`, `src/components/ImageModal/ImageModal.module.css`
 - [ ] **24. Add more responsive breakpoints** (~4 hrs) — CSS modules throughout
 - [ ] **25. Add visible focus states to all interactive elements** (~2 hrs) — CSS modules throughout
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -73,7 +73,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 
 ## Accessibility
 
-- [ ] **23. Add ARIA roles to image modals** (~3 hrs) — `src/components/ImageModal/ModalContent/ModalContent.tsx`
+- [x] **23. Add ARIA roles to image modals** (~3 hrs) — `src/components/ImageModal/ModalContent/ModalContent.tsx`, `ImageModal.tsx`, `ImageModal.module.css`
 - [ ] **24. Add more responsive breakpoints** (~4 hrs) — CSS modules throughout
 - [ ] **25. Add visible focus states to all interactive elements** (~2 hrs) — CSS modules throughout
 

--- a/src/components/ImageModal/ImageModal.module.css
+++ b/src/components/ImageModal/ImageModal.module.css
@@ -111,6 +111,16 @@
     color: var(--color-bg-modal);
 }
 
+.closeButton:focus-visible {
+    outline: 0.2rem solid var(--color-accent-blue);
+    outline-offset: 0.15rem;
+}
+
+.modalImageLink:focus-visible {
+    outline: 0.2rem solid var(--color-accent-blue);
+    outline-offset: 0.15rem;
+}
+
 .modalImage {
     border: var(--color-black) 0.25rem solid;
     width: 100%;

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -20,10 +20,7 @@ export default function ImageModal({ data }: ImageModalProps) {
         document.body.style.overflow = 'hidden'
 
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                setModalOpen(false)
-                triggerRef.current?.focus()
-            }
+            if (e.key === 'Escape') setModalOpen(false)
         }
         document.addEventListener('keydown', handleKeyDown)
 
@@ -31,6 +28,7 @@ export default function ImageModal({ data }: ImageModalProps) {
             if (appContent) appContent.inert = false
             document.body.style.overflow = ''
             document.removeEventListener('keydown', handleKeyDown)
+            triggerRef.current?.focus()
         }
     }, [modalOpen])
 
@@ -90,10 +88,7 @@ export default function ImageModal({ data }: ImageModalProps) {
             {modalOpen &&
                 createPortal(
                     <ModalContent
-                        onClose={() => {
-                            setModalOpen(false)
-                            triggerRef.current?.focus()
-                        }}
+                        onClose={() => setModalOpen(false)}
                         data={data}
                     />,
                     document.getElementById('modal-root')!,

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -15,10 +15,9 @@ export default function ImageModal({ data }: ImageModalProps) {
     useEffect(() => {
         if (!modalOpen) return
 
-        const appContent = document.getElementById('modal-root')
-            ?.previousElementSibling as HTMLElement | null
-
+        const appContent = document.getElementById('app-content')
         if (appContent) appContent.inert = true
+        document.body.style.overflow = 'hidden'
 
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
@@ -30,6 +29,7 @@ export default function ImageModal({ data }: ImageModalProps) {
 
         return () => {
             if (appContent) appContent.inert = false
+            document.body.style.overflow = ''
             document.removeEventListener('keydown', handleKeyDown)
         }
     }, [modalOpen])

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -1,6 +1,6 @@
 import ModalContent from './ModalContent/ModalContent'
 import styles from './ImageModal.module.css'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { Image } from '~/lib/types'
 
@@ -10,6 +10,29 @@ interface ImageModalProps {
 
 export default function ImageModal({ data }: ImageModalProps) {
     const [modalOpen, setModalOpen] = useState(false)
+    const triggerRef = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+        if (!modalOpen) return
+
+        const appContent = document.getElementById('modal-root')
+            ?.previousElementSibling as HTMLElement | null
+
+        if (appContent) appContent.inert = true
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                setModalOpen(false)
+                triggerRef.current?.focus()
+            }
+        }
+        document.addEventListener('keydown', handleKeyDown)
+
+        return () => {
+            if (appContent) appContent.inert = false
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [modalOpen])
 
     function assignHoverColors() {
         const imageContainers = document.getElementsByClassName(
@@ -50,8 +73,10 @@ export default function ImageModal({ data }: ImageModalProps) {
                 <h5 className={styles.thumbnailTitle}>{data.title}</h5>
             </a>
             <button
+                ref={triggerRef}
                 className={styles.modalButton}
                 onClick={() => setModalOpen(true)}
+                aria-label={`View ${data.title} in full size`}
             >
                 <img
                     src={data.url}
@@ -65,7 +90,10 @@ export default function ImageModal({ data }: ImageModalProps) {
             {modalOpen &&
                 createPortal(
                     <ModalContent
-                        onClose={() => setModalOpen(false)}
+                        onClose={() => {
+                            setModalOpen(false)
+                            triggerRef.current?.focus()
+                        }}
                         data={data}
                     />,
                     document.getElementById('modal-root')!,

--- a/src/components/ImageModal/ModalContent/ModalContent.tsx
+++ b/src/components/ImageModal/ModalContent/ModalContent.tsx
@@ -48,6 +48,7 @@ export default function ModalContent({ onClose, data }: ModalContentProps) {
                 <a
                     href={`/images/${data.image_id}`}
                     className={styles.modalImageLink}
+                    aria-label={`View full details for ${data.title}`}
                 >
                     <img
                         src={data.url}

--- a/src/components/ImageModal/ModalContent/ModalContent.tsx
+++ b/src/components/ImageModal/ModalContent/ModalContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import styles from '../ImageModal.module.css'
 import type { Image } from '~/lib/types'
 
@@ -7,18 +8,38 @@ interface ModalContentProps {
 }
 
 export default function ModalContent({ onClose, data }: ModalContentProps) {
+    const closeRef = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+        closeRef.current?.focus()
+    }, [])
+
     return (
         <>
-            <div className={styles.overlay} onClick={() => onClose()} />
-            <div className={styles.modalContent} id={data.url}>
+            <div
+                className={styles.overlay}
+                onClick={() => onClose()}
+                aria-hidden="true"
+            />
+            <div
+                className={styles.modalContent}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={`modal-title-${data.image_id}`}
+            >
                 <div className={styles.modalHeader}>
-                    <p className={styles.imageTitle}>
+                    <p
+                        className={styles.imageTitle}
+                        id={`modal-title-${data.image_id}`}
+                    >
                         {data.title}, {data.location}
                     </p>
                     <button
+                        ref={closeRef}
                         className={styles.closeButton}
                         type="button"
                         onClick={() => onClose()}
+                        aria-label="Close modal"
                     >
                         X
                     </button>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -45,7 +45,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
                 <HeadContent />
             </head>
             <body>
-                {children}
+                <div id="app-content">{children}</div>
                 <div id="modal-root"></div>
                 <Scripts />
             </body>


### PR DESCRIPTION
## Summary
- Add `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the modal dialog
- Add `aria-label` to the close button ("Close modal") and trigger button ("View X in full size")
- Add `aria-hidden="true"` to the backdrop overlay
- Add Escape key to close the modal
- Use `inert` on page content behind the modal to prevent background interaction
- Auto-focus the close button when the modal opens, restore focus to trigger on close
- Add `:focus-visible` outlines on the close button and image link

## Test plan
- [ ] Open a modal and press Escape — modal should close
- [ ] Open a modal and press Tab — focus should cycle within the modal only
- [ ] Open a modal — close button should be focused immediately
- [ ] Close a modal — focus should return to the thumbnail that opened it
- [ ] Verify focus outlines are visible when tabbing through modal elements
- [ ] Run VoiceOver — modal should announce as a dialog with the image title

🤖 Generated with [Claude Code](https://claude.com/claude-code)