### PR TITLE
Add structured data (JSON-LD) to image and collection pages

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -66,7 +66,7 @@ Ordered by priority — quick wins first, then CI/testing foundation, then every
 
 - [x] **19. Add `sitemap.xml` and `robots.txt`** (~3 hrs) — `public/robots.txt`, `src/routes/api/sitemap.ts`
 - [x] **20. Add canonical tags to all pages** (~1 hr) — Route `head()` functions
-- [ ] **21. Add structured data (JSON-LD)** (~3 hrs) — `src/routes/images/$id.tsx`, `src/routes/collections/$id.tsx`
+- [x] **21. Add structured data (JSON-LD)** (~3 hrs) — `src/routes/images/$id.tsx`, `src/routes/collection/$id.tsx`
 - [x] **22. Add OG tags to collection pages** (~1 hr) — `src/routes/collection/$id.tsx`
 
 ---

--- a/src/routes/collection/$id.tsx
+++ b/src/routes/collection/$id.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/collection/$id')({
                   image: collection.cover_url,
                   author: {
                       '@type': 'Person',
-                      name: 'Lewis Inches',
+                      name: 'Loowis',
                   },
                   ...(collection.collection_description && {
                       description: collection.collection_description,

--- a/src/routes/collection/$id.tsx
+++ b/src/routes/collection/$id.tsx
@@ -18,30 +18,54 @@ export const Route = createFileRoute('/collection/$id')({
         if (!result) throw notFound()
         return result
     },
-    head: ({ loaderData, match }) => ({
-        meta: [
-            {
-                title: `${loaderData?.collection?.collection_name ?? 'Collection'} | Loowis Photography`,
-            },
-            {
-                name: 'og:title',
-                content: `${loaderData?.collection?.collection_name ?? 'Collection'} | Loowis Photography`,
-            },
-            {
-                name: 'og:description',
-                content:
-                    loaderData?.collection?.collection_description ||
-                    'Photography by Loowis',
-            },
-            {
-                name: 'og:image',
-                content: loaderData?.collection?.cover_url ?? '',
-            },
-            { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
-            { name: 'og:type', content: 'website' },
-        ],
-        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
-    }),
+    head: ({ loaderData, match }) => {
+        const collection = loaderData?.collection
+        const title = `${collection?.collection_name ?? 'Collection'} | Loowis Photography`
+        const jsonLd = collection
+            ? {
+                  '@context': 'https://schema.org',
+                  '@type': 'ImageGallery',
+                  name: collection.collection_name,
+                  url: `${BASE_URL}${match.pathname}`,
+                  image: collection.cover_url,
+                  author: {
+                      '@type': 'Person',
+                      name: 'Lewis Inches',
+                  },
+                  ...(collection.collection_description && {
+                      description: collection.collection_description,
+                  }),
+              }
+            : null
+
+        return {
+            meta: [
+                { title },
+                { name: 'og:title', content: title },
+                {
+                    name: 'og:description',
+                    content:
+                        collection?.collection_description ||
+                        'Photography by Loowis',
+                },
+                {
+                    name: 'og:image',
+                    content: collection?.cover_url ?? '',
+                },
+                { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
+                { name: 'og:type', content: 'website' },
+            ],
+            links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
+            scripts: jsonLd
+                ? [
+                      {
+                          type: 'application/ld+json',
+                          children: JSON.stringify(jsonLd),
+                      },
+                  ]
+                : [],
+        }
+    },
     component: Collection,
 })
 

--- a/src/routes/images/$id.tsx
+++ b/src/routes/images/$id.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/images/$id')({
                   url: `${BASE_URL}${match.pathname}`,
                   author: {
                       '@type': 'Person',
-                      name: 'Lewis Inches',
+                      name: 'Loowis',
                   },
                   ...(loaderData.description && {
                       description: loaderData.description,

--- a/src/routes/images/$id.tsx
+++ b/src/routes/images/$id.tsx
@@ -11,25 +11,57 @@ export const Route = createFileRoute('/images/$id')({
         if (!image) throw notFound()
         return image
     },
-    head: ({ loaderData, match }) => ({
-        meta: [
-            {
-                title: `${loaderData?.title ?? 'Image'} | Loowis Photography`,
-            },
-            {
-                name: 'og:title',
-                content: `${loaderData?.title ?? 'Image'} | Loowis Photography`,
-            },
-            {
-                name: 'og:description',
-                content: loaderData?.description || 'Photography by Loowis',
-            },
-            { name: 'og:image', content: loaderData?.url ?? '' },
-            { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
-            { name: 'og:type', content: 'website' },
-        ],
-        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
-    }),
+    head: ({ loaderData, match }) => {
+        const title = `${loaderData?.title ?? 'Image'} | Loowis Photography`
+        const jsonLd = loaderData
+            ? {
+                  '@context': 'https://schema.org',
+                  '@type': 'Photograph',
+                  name: loaderData.title,
+                  image: loaderData.url,
+                  url: `${BASE_URL}${match.pathname}`,
+                  author: {
+                      '@type': 'Person',
+                      name: 'Lewis Inches',
+                  },
+                  ...(loaderData.description && {
+                      description: loaderData.description,
+                  }),
+                  ...(loaderData.date_taken && {
+                      dateCreated: loaderData.date_taken,
+                  }),
+                  ...(loaderData.location && {
+                      contentLocation: {
+                          '@type': 'Place',
+                          name: loaderData.location,
+                      },
+                  }),
+              }
+            : null
+
+        return {
+            meta: [
+                { title },
+                { name: 'og:title', content: title },
+                {
+                    name: 'og:description',
+                    content: loaderData?.description || 'Photography by Loowis',
+                },
+                { name: 'og:image', content: loaderData?.url ?? '' },
+                { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
+                { name: 'og:type', content: 'website' },
+            ],
+            links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
+            scripts: jsonLd
+                ? [
+                      {
+                          type: 'application/ld+json',
+                          children: JSON.stringify(jsonLd),
+                      },
+                  ]
+                : [],
+        }
+    },
     component: Photo,
 })
 


### PR DESCRIPTION
## Summary
- Add `Photograph` JSON-LD schema to `/images/$id` pages with name, image URL, author, description, date, and location
- Add `ImageGallery` JSON-LD schema to `/collection/$id` pages with name, cover image, author, and description
- Uses TanStack's `head()` `scripts` array to inject `<script type="application/ld+json">` in the `<head>`
- Mark item #21 as done in IMPROVEMENTS.md

## Test plan
- [ ] Visit an image page and inspect the `<head>` for a `<script type="application/ld+json">` containing `Photograph` schema
- [ ] Visit a collection page and inspect the `<head>` for `ImageGallery` schema
- [ ] Validate with [Google's Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)