### PR TITLE
Stop tracking .sentryclirc

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,3 +1,0 @@
-
-[auth]
-token=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


### PR DESCRIPTION
## Summary
- `.sentryclirc` was committed in 415692d and has been sitting in git history with a live-looking Sentry auth token, despite `.gitignore` listing it (which only prevents future commits, not already-tracked files).
- Untracks the file going forward.

## Follow-up (not covered by this PR)
- Rotate the token in Sentry's dashboard — untracking doesn't invalidate a key that's already been exposed.

## Test plan
- [x] `git ls-files` no longer lists `.sentryclirc`