### PR TITLE
Fix double image fetch in ImageModal

### DIFF
--- a/src/components/ImageModal/ImageModal.module.css
+++ b/src/components/ImageModal/ImageModal.module.css
@@ -11,7 +11,6 @@
 }
 
 .mobileLink {
-    display: none;
     color: var(--color-black);
     text-decoration: none;
 }
@@ -135,14 +134,4 @@
     font-family: josefin-bold;
     font-size: large;
     width: 100%;
-}
-
-@media (width <= 1320px) {
-    .mobileLink {
-        display: block;
-    }
-
-    .modalButton {
-        display: none;
-    }
 }

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -8,9 +8,27 @@ interface ImageModalProps {
     data: Image
 }
 
+const MOBILE_MEDIA_QUERY = '(width <= 1320px)'
+
+function useIsMobile() {
+    const [isMobile, setIsMobile] = useState(false)
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY)
+        setIsMobile(mediaQuery.matches)
+
+        const handleChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+        mediaQuery.addEventListener('change', handleChange)
+        return () => mediaQuery.removeEventListener('change', handleChange)
+    }, [])
+
+    return isMobile
+}
+
 export default function ImageModal({ data }: ImageModalProps) {
     const [modalOpen, setModalOpen] = useState(false)
     const triggerRef = useRef<HTMLButtonElement>(null)
+    const isMobile = useIsMobile()
 
     useEffect(() => {
         if (!modalOpen) return
@@ -60,31 +78,37 @@ export default function ImageModal({ data }: ImageModalProps) {
 
     return (
         <article className={styles.imageContainer}>
-            <a className={styles.mobileLink} href={`/images/${data.image_id}`}>
-                <img
-                    src={data.url}
-                    alt={data.alt_text ?? ''}
-                    width={data.width}
-                    height={data.height}
-                    className={styles.image}
-                />
-                <h5 className={styles.thumbnailTitle}>{data.title}</h5>
-            </a>
-            <button
-                ref={triggerRef}
-                className={styles.modalButton}
-                onClick={() => setModalOpen(true)}
-                aria-label={`View ${data.title} in full size`}
-            >
-                <img
-                    src={data.url}
-                    alt={data.alt_text ?? ''}
-                    width={data.width}
-                    height={data.height}
-                    className={styles.image}
-                />
-                <h5 className={styles.thumbnailTitle}>{data.title}</h5>
-            </button>
+            {isMobile ? (
+                <a
+                    className={styles.mobileLink}
+                    href={`/images/${data.image_id}`}
+                >
+                    <img
+                        src={data.url}
+                        alt={data.alt_text ?? ''}
+                        width={data.width}
+                        height={data.height}
+                        className={styles.image}
+                    />
+                    <h5 className={styles.thumbnailTitle}>{data.title}</h5>
+                </a>
+            ) : (
+                <button
+                    ref={triggerRef}
+                    className={styles.modalButton}
+                    onClick={() => setModalOpen(true)}
+                    aria-label={`View ${data.title} in full size`}
+                >
+                    <img
+                        src={data.url}
+                        alt={data.alt_text ?? ''}
+                        width={data.width}
+                        height={data.height}
+                        className={styles.image}
+                    />
+                    <h5 className={styles.thumbnailTitle}>{data.title}</h5>
+                </button>
+            )}
             {modalOpen &&
                 createPortal(
                     <ModalContent


### PR DESCRIPTION
## Summary
- `ImageModal` rendered both a mobile `<a>` and a desktop `<button>` variant, each with its own `<img src>`, and used a CSS breakpoint to hide one. Browsers fetch both `<img>` sources regardless of `display: none`, so every gallery page downloaded roughly double the image bytes it needed.
- Replaced the CSS-only toggle with a `useIsMobile` hook (backed by `matchMedia` on the same `1320px` breakpoint) that renders a single `<img>` inside whichever wrapper (link vs. button) is appropriate.

## Test plan
- [x] `npm run lint`
- [x] `npm run build` (vite build + tsc --noEmit)
- [x] `npm test`
- [ ] Manual check in browser at both mobile and desktop widths (resize across 1320px) to confirm correct link/button behavior

Fixes #194