### PR TITLE
Lazy-load gallery thumbnails

### DIFF
--- a/src/components/CollectionPreview/CollectionPreview.tsx
+++ b/src/components/CollectionPreview/CollectionPreview.tsx
@@ -29,6 +29,8 @@ export default function CollectionPreview({
                     alt={name}
                     width={width}
                     height={height}
+                    loading="lazy"
+                    decoding="async"
                     style={{
                         width: '100%',
                         height: 'auto',

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -89,6 +89,8 @@ export default function ImageModal({ data }: ImageModalProps) {
                         width={data.width}
                         height={data.height}
                         className={styles.image}
+                        loading="lazy"
+                        decoding="async"
                     />
                     <h5 className={styles.thumbnailTitle}>{data.title}</h5>
                 </a>
@@ -105,6 +107,8 @@ export default function ImageModal({ data }: ImageModalProps) {
                         width={data.width}
                         height={data.height}
                         className={styles.image}
+                        loading="lazy"
+                        decoding="async"
                     />
                     <h5 className={styles.thumbnailTitle}>{data.title}</h5>
                 </button>


### PR DESCRIPTION
## Summary
- Thumbnail `<img>` tags had no `loading`/`decoding` hints, so a page of 40 photos fetched all 40 immediately instead of only what's near the viewport.
- Added `loading="lazy" decoding="async"` to the thumbnail images in `ImageModal` (shared by home, all-images, collection, and search grids) and `CollectionPreview` (collections listing page cover images).
- Left the single hero image in `ImagePage` (image detail page) eager since it's the primary above-the-fold content.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Manual check: scroll a gallery page in devtools network tab and confirm below-the-fold thumbnails don't fetch until scrolled into view

Fixes #195