### PR TITLE
Wrap page content in <main> landmark in Layout

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 navLinks={['/all-images', '/collections', '/image-map']}
                 handleSearch={handleSearchEvent}
             />
-            {children}
+            <main>{children}</main>
         </>
     )
 }


### PR DESCRIPTION
## Summary
- Lighthouse's `landmark-one-main` accessibility audit scored 0 on every page because `Layout.tsx` rendered `<Header>` followed directly by `{children}`, with no `<main>` (or `role="main"`) wrapper anywhere in the app.
- Wraps `{children}` in a `<main>` element in `src/components/Layout/Layout.tsx` so screen reader users get a landmark to jump straight to page content.
- No paired `.module.css` exists for `Layout.tsx` and no global styles target it, so this introduces no layout shift.

Fixes #205

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format` — no new issues from this change (pre-existing repo-wide CRLF/EOL warnings on this Windows checkout are unrelated to the diff; CI runs on `ubuntu-latest` so they don't apply there; verified `Layout.tsx` content passes `prettier --check --end-of-line crlf`)
- [x] `npm test` — 37 tests passed
- [x] `npm run build` (vite build + `tsc --noEmit`) — succeeds