### PR TITLE
Fix search sanitization stripping valid punctuation

### DIFF
--- a/src/lib/server/search-utils.ts
+++ b/src/lib/server/search-utils.ts
@@ -1,0 +1,6 @@
+// Escapes ILIKE wildcards (% and _) and the escape character itself (\) so
+// user input can't inject unintended wildcards; the tagged `sql` template
+// still handles SQL-injection safety via parameterization.
+export function escapeLikeWildcards(input: string): string {
+    return input.replace(/[\\%_]/g, (char) => `\\${char}`)
+}

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect } from 'vitest'
-
-// Test the ILIKE-wildcard escaping directly — the server function itself
-// requires createServerFn infrastructure, but the core logic is testable.
-// This only escapes "%"/"_"/"\" (ILIKE's wildcard and escape characters);
-// it does not strip other punctuation. SQL injection is not a concern here
-// because the value is still passed through the tagged `sql` template,
-// which parameterizes it — this function only prevents user input from
-// being interpreted as ILIKE wildcards.
-const escapeLikeWildcards = (input: string) =>
-    input.replace(/[\\%_]/g, (char) => `\\${char}`)
+import { escapeLikeWildcards } from './search-utils'
 
 describe('search query wildcard escaping', () => {
     it('preserves alphanumeric characters', () => {

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -1,39 +1,62 @@
 import { describe, it, expect } from 'vitest'
 
-// Test the sanitisation regex directly — the server function itself
-// requires createServerFn infrastructure, but the core logic is testable
-const sanitise = (query: string) => query.replace(/[^a-zA-Z0-9 ]/g, '')
+// Test the ILIKE-wildcard escaping directly — the server function itself
+// requires createServerFn infrastructure, but the core logic is testable.
+// This only escapes "%"/"_"/"\" (ILIKE's wildcard and escape characters);
+// it does not strip other punctuation. SQL injection is not a concern here
+// because the value is still passed through the tagged `sql` template,
+// which parameterizes it — this function only prevents user input from
+// being interpreted as ILIKE wildcards.
+const escapeLikeWildcards = (input: string) =>
+    input.replace(/[\\%_]/g, (char) => `\\${char}`)
 
-describe('search query sanitisation', () => {
+describe('search query wildcard escaping', () => {
     it('preserves alphanumeric characters', () => {
-        expect(sanitise('hello world')).toBe('hello world')
+        expect(escapeLikeWildcards('hello world')).toBe('hello world')
     })
 
     it('preserves numbers', () => {
-        expect(sanitise('photo 123')).toBe('photo 123')
+        expect(escapeLikeWildcards('photo 123')).toBe('photo 123')
     })
 
-    it('strips SQL wildcards', () => {
-        expect(sanitise('%test_query%')).toBe('testquery')
+    it('preserves periods and hyphens', () => {
+        expect(escapeLikeWildcards('St. Andrews')).toBe('St. Andrews')
+        expect(escapeLikeWildcards('Stratford-upon-Avon')).toBe(
+            'Stratford-upon-Avon',
+        )
     })
 
-    it('strips quotes and semicolons', () => {
-        expect(sanitise("'; DROP TABLE images;--")).toBe(' DROP TABLE images')
+    it('preserves apostrophes', () => {
+        expect(escapeLikeWildcards("St Mary's Church")).toBe("St Mary's Church")
     })
 
-    it('strips special characters', () => {
-        expect(sanitise('hello@world#2024!')).toBe('helloworld2024')
+    it('escapes ILIKE wildcard percent signs', () => {
+        expect(escapeLikeWildcards('%test%')).toBe('\\%test\\%')
+    })
+
+    it('escapes ILIKE wildcard underscores', () => {
+        expect(escapeLikeWildcards('test_query')).toBe('test\\_query')
+    })
+
+    it('escapes a literal backslash', () => {
+        expect(escapeLikeWildcards('back\\slash')).toBe('back\\\\slash')
+    })
+
+    it('does not strip quotes and semicolons (parameterized query handles safety)', () => {
+        expect(escapeLikeWildcards("'; DROP TABLE images;--")).toBe(
+            "'; DROP TABLE images;--",
+        )
     })
 
     it('handles empty string', () => {
-        expect(sanitise('')).toBe('')
+        expect(escapeLikeWildcards('')).toBe('')
     })
 
-    it('handles string with only special characters', () => {
-        expect(sanitise('!@#$%^&*()')).toBe('')
+    it('handles string with only wildcard characters', () => {
+        expect(escapeLikeWildcards('%_%')).toBe('\\%\\_\\%')
     })
 
     it('preserves spaces between words', () => {
-        expect(sanitise('new york city')).toBe('new york city')
+        expect(escapeLikeWildcards('new york city')).toBe('new york city')
     })
 })

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -1,15 +1,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import { getDb } from '~/lib/db'
 import type { Image } from '~/lib/types'
-
-// Escape ILIKE wildcard characters (% and _) plus the escape character
-// itself (\), so user input can't inject unintended wildcard matches.
-// This is not SQL-injection protection — the tagged `sql` template already
-// parameterizes values — it just keeps "%"/"_" in a search query literal.
-// Postgres' LIKE/ILIKE default escape character is backslash.
-function escapeLikeWildcards(input: string): string {
-    return input.replace(/[\\%_]/g, (char) => `\\${char}`)
-}
+import { escapeLikeWildcards } from '~/lib/server/search-utils'
 
 export const searchImages = createServerFn({ method: 'POST' })
     .inputValidator((d: string) => d)

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -2,11 +2,20 @@ import { createServerFn } from '@tanstack/react-start'
 import { getDb } from '~/lib/db'
 import type { Image } from '~/lib/types'
 
+// Escape ILIKE wildcard characters (% and _) plus the escape character
+// itself (\), so user input can't inject unintended wildcard matches.
+// This is not SQL-injection protection — the tagged `sql` template already
+// parameterizes values — it just keeps "%"/"_" in a search query literal.
+// Postgres' LIKE/ILIKE default escape character is backslash.
+function escapeLikeWildcards(input: string): string {
+    return input.replace(/[\\%_]/g, (char) => `\\${char}`)
+}
+
 export const searchImages = createServerFn({ method: 'POST' })
     .inputValidator((d: string) => d)
     .handler(async ({ data: query }) => {
         try {
-            const safeQuery = query.replace(/[^a-zA-Z0-9 ]/g, '')
+            const safeQuery = escapeLikeWildcards(query)
             const sql = getDb()
             const results = await sql`
                 SELECT * FROM images


### PR DESCRIPTION
## Summary
- `searchImages` previously stripped everything except letters/digits/spaces from the search query before matching, so legitimate queries like "St. Andrews" or "Stratford-upon-Avon" never matched anything.
- That stripping wasn't actually protecting against SQL injection — `getDb()` returns Neon's tagged `sql` template, which already parameterizes values passed via `${}`.
- Replaced the alphanumeric-stripping regex with `escapeLikeWildcards()`, which only escapes the ILIKE wildcard characters (`%`, `_`) and the backslash escape character, so arbitrary punctuation in a query is preserved while the query can't be hijacked with unintended wildcard matches (Postgres' `LIKE`/`ILIKE` default escape character is backslash).

Fixes #201

## Test plan
- Updated `src/lib/server/search.test.ts` to cover the new escaping function: preserves periods/hyphens/apostrophes (`"St. Andrews"`, `"Stratford-upon-Avon"`, `"St Mary's Church"`), escapes literal `%`/`_`/`\` characters, and confirms quotes/semicolons are no longer stripped (safety now comes from parameterization, not stripping).
- `npm run lint` — passes
- `npm run format` — passes (on changed files)
- `npm test` — all 40 unit tests pass
- `npm run build` (vite build + `tsc --noEmit`) — passes