### PR TITLE
Add visually-hidden h1 to homepage

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -26,6 +26,7 @@ function Home() {
     return (
         <Layout>
             <section>
+                <h1 className={styles.visuallyHidden}>Loowis Photography</h1>
                 <div className={styles.container}>
                     <div className={styles.formatSelection}>
                         <button

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -1,3 +1,15 @@
+.visuallyHidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .container {
     text-align: center;
     width: 75%;


### PR DESCRIPTION
## Summary
- Fixes #206: Lighthouse's `heading-order` audit failed on the homepage because it never rendered an `h1` — the first heading encountered was the `h5` thumbnail caption inside `ImageModal`/`CollectionPreview`.
- Adds a visually-hidden `h1` ("Loowis Photography") at the top of the homepage's `<section>`, following the same pattern other top-level routes use (e.g. `all-images.tsx`'s `h1.header`), but hidden off-screen since there's no natural visible heading slot in the current design.

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (includes `tsc --noEmit`)
- [x] Manually verified the homepage now has an `h1` before any `h5` thumbnail captions in the DOM order

🤖 Generated with [Claude Code](https://claude.com/claude-code)