### PR TITLE
Stop loading leaflet CSS on every page

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,7 +9,6 @@ import * as React from 'react'
 import ErrorFallback from '~/components/ErrorFallback/ErrorFallback'
 import globalsCss from '~/styles/globals.css?url'
 import componentLibCss from 'loowis-component-library/dist/index.css?url'
-import leafletCss from 'leaflet/dist/leaflet.css?url'
 
 export const Route = createRootRoute({
     head: () => ({
@@ -29,7 +28,6 @@ export const Route = createRootRoute({
         links: [
             { rel: 'stylesheet', href: globalsCss },
             { rel: 'stylesheet', href: componentLibCss },
-            { rel: 'stylesheet', href: leafletCss },
             { rel: 'icon', href: '/favicon/favicon.png' },
         ],
     }),

--- a/src/routes/admin/edit/image/$id.tsx
+++ b/src/routes/admin/edit/image/$id.tsx
@@ -4,9 +4,13 @@ import Layout from '~/components/Layout/Layout'
 import PhotoForm from '~/components/PhotoForm/PhotoForm'
 import { getAdminImage, updateImage } from '~/lib/server/admin-images'
 import styles from '~/styles/admin/edit-image.module.css'
+import leafletCss from 'leaflet/dist/leaflet.css?url'
 
 export const Route = createFileRoute('/admin/edit/image/$id')({
     loader: ({ params: { id } }) => getAdminImage({ data: id }),
+    head: () => ({
+        links: [{ rel: 'stylesheet', href: leafletCss }],
+    }),
     component: EditImage,
 })
 

--- a/src/routes/admin/new/image.tsx
+++ b/src/routes/admin/new/image.tsx
@@ -3,8 +3,12 @@ import Layout from '~/components/Layout/Layout'
 import PhotoForm from '~/components/PhotoForm/PhotoForm'
 import { createImage } from '~/lib/server/admin-images'
 import styles from '~/styles/admin/new-image.module.css'
+import leafletCss from 'leaflet/dist/leaflet.css?url'
 
 export const Route = createFileRoute('/admin/new/image')({
+    head: () => ({
+        links: [{ rel: 'stylesheet', href: leafletCss }],
+    }),
     component: NewImage,
 })
 

--- a/src/routes/image-map.tsx
+++ b/src/routes/image-map.tsx
@@ -4,12 +4,16 @@ import { useEffect } from 'react'
 import Layout from '~/components/Layout/Layout'
 import { getImagesForMap } from '~/lib/server/images'
 import styles from '~/styles/pages/image-map.module.css'
+import leafletCss from 'leaflet/dist/leaflet.css?url'
 
 export const Route = createFileRoute('/image-map')({
     loader: () => getImagesForMap(),
     head: ({ match }) => ({
         meta: [{ title: 'Image Map | Lewis Inches - Photography' }],
-        links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
+        links: [
+            { rel: 'canonical', href: `${BASE_URL}${match.pathname}` },
+            { rel: 'stylesheet', href: leafletCss },
+        ],
     }),
     component: ImageMap,
 })

--- a/src/routes/images/$id.tsx
+++ b/src/routes/images/$id.tsx
@@ -4,6 +4,7 @@ import Layout from '~/components/Layout/Layout'
 import ImagePage from '~/components/ImagePage/ImagePage'
 import { getImageById } from '~/lib/server/images'
 import styles from '~/styles/pages/image.module.css'
+import leafletCss from 'leaflet/dist/leaflet.css?url'
 
 export const Route = createFileRoute('/images/$id')({
     loader: async ({ params: { id } }) => {
@@ -51,7 +52,10 @@ export const Route = createFileRoute('/images/$id')({
                 { name: 'og:url', content: `${BASE_URL}${match.pathname}` },
                 { name: 'og:type', content: 'website' },
             ],
-            links: [{ rel: 'canonical', href: `${BASE_URL}${match.pathname}` }],
+            links: [
+                { rel: 'canonical', href: `${BASE_URL}${match.pathname}` },
+                { rel: 'stylesheet', href: leafletCss },
+            ],
             scripts: jsonLd
                 ? [
                       {


### PR DESCRIPTION
Fixes #208

## Problem

Lighthouse's render-blocking-insight audit flagged 6 synchronous stylesheets in `<head>` on the homepage: two `index-*.css` chunks, `main-*.css`, `leaflet-*.css`, `ImageModal-*.css`, and `globals-*.css`.

Investigation showed `leaflet-*.css` (~15.6kB, the largest of the six) was the one clear bug: `src/routes/__root.tsx` linked `leaflet/dist/leaflet.css` unconditionally on every single page, even though the leaflet *JS* is already dynamic-imported (`import('leaflet')`) and only actually used on four routes — the image map, an image's detail page (when it has coordinates), and the two admin photo forms (location picker). Every other page (home, all-images, collections, collection detail, search) was paying for a map stylesheet it never renders.

The other five stylesheets (`globals`, the component-library CSS, the route's own CSS module, the router-entry CSS, and `ImageModal.module.css`) are all genuinely needed for first paint of their respective routes — `ImageModal` in particular renders the visible gallery thumbnails, not just the lazily-opened modal — so consolidating or deferring those further looked riskier for the LCP payoff, especially since the issue itself calls out that this is worth re-measuring after the separate image-resizing/dual-gallery work lands.

## Fix

Moved the `leaflet.css` `<link>` out of the root route and into the `head()` of only the routes that render a leaflet map:
- `src/routes/image-map.tsx`
- `src/routes/images/$id.tsx`
- `src/routes/admin/new/image.tsx`
- `src/routes/admin/edit/image/$id.tsx`

## Before / after

Verified against a production build + `vite preview`:

- **Before**: `/` `<head>` included `globals`, `index` (component-library), `main`, `index` (page), `ImageModal`, **and `leaflet`** — 6 stylesheets.
- **After**: `/` `<head>` includes `globals`, `index` (component-library), `main`, `index` (page), `ImageModal` — leaflet is gone. `/image-map`, `/images/$id`, `/admin/new/image`, and `/admin/edit/image/$id` still correctly load `leaflet-*.css`.

No JS chunking changed — leaflet's JS was already lazy; this just makes its CSS match.

## Test plan

- [x] `npm run build` — inspected `dist/client/assets` CSS chunk output, unchanged set of files, but confirmed via `vite preview` that `leaflet-*.css` is no longer referenced from `/`, `/all-images`, `/collections`, `/collection/$id`, or `/search/$query`, and is still referenced from `/image-map`, `/images/$id`, `/admin/new/image`, `/admin/edit/image/$id`.
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm test` (37 tests)
- [x] `npm run test:e2e` (26 tests, including Image Map and Image Detail specs)