### PR TITLE
Serve resized thumbnails via Cloudflare Image Resizing

### DIFF
--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import styles from './CollectionForm.module.css'
 import { useFormFeedback } from '~/hooks/useFormFeedback'
+import { getResizedImageUrl } from '~/lib/images'
 import type { Image } from '~/lib/types'
 
 interface CollectionFormProps {
@@ -145,7 +146,10 @@ export default function CollectionForm({
                                             className={styles.imageItem}
                                         >
                                             <img
-                                                src={img.url}
+                                                src={getResizedImageUrl(
+                                                    img.url,
+                                                    'thumbnail',
+                                                )}
                                                 alt={img.title}
                                                 onClick={() =>
                                                     setSelectedImages(

--- a/src/components/CollectionPreview/CollectionPreview.module.css
+++ b/src/components/CollectionPreview/CollectionPreview.module.css
@@ -9,6 +9,7 @@
 
 .collectionpreview {
     display: block;
+    width: 100%;
     text-decoration: none;
     color: var(--color-accent-teal);
     opacity: 75%;

--- a/src/components/CollectionPreview/CollectionPreview.module.css
+++ b/src/components/CollectionPreview/CollectionPreview.module.css
@@ -8,6 +8,7 @@
 }
 
 .collectionpreview {
+    display: block;
     text-decoration: none;
     color: var(--color-accent-teal);
     opacity: 75%;

--- a/src/components/CollectionPreview/CollectionPreview.tsx
+++ b/src/components/CollectionPreview/CollectionPreview.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import styles from './CollectionPreview.module.css'
+import { getResizedImageUrl } from '~/lib/images'
 
 interface CollectionPreviewProps {
     name: string
@@ -25,7 +26,7 @@ export default function CollectionPreview({
                 search={{ page: 1, sort: 'date-desc', filter: 'all' }}
             >
                 <img
-                    src={cover_url}
+                    src={getResizedImageUrl(cover_url, 'thumbnail')}
                     alt={name}
                     width={width}
                     height={height}

--- a/src/components/ImageModal/ImageModal.module.css
+++ b/src/components/ImageModal/ImageModal.module.css
@@ -12,12 +12,14 @@
 
 .mobileLink {
     display: block;
+    width: 100%;
     color: var(--color-black);
     text-decoration: none;
 }
 
 .modalButton {
     display: block;
+    width: 100%;
     transition: 0.3s;
     background-color: transparent;
     border: none;
@@ -119,6 +121,7 @@
 
 .modalImageLink {
     display: block;
+    width: 100%;
 }
 
 .modalImageLink:focus-visible {

--- a/src/components/ImageModal/ImageModal.module.css
+++ b/src/components/ImageModal/ImageModal.module.css
@@ -11,11 +11,13 @@
 }
 
 .mobileLink {
+    display: block;
     color: var(--color-black);
     text-decoration: none;
 }
 
 .modalButton {
+    display: block;
     transition: 0.3s;
     background-color: transparent;
     border: none;
@@ -113,6 +115,10 @@
 .closeButton:focus-visible {
     outline: 0.2rem solid var(--color-accent-blue);
     outline-offset: 0.15rem;
+}
+
+.modalImageLink {
+    display: block;
 }
 
 .modalImageLink:focus-visible {

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -2,6 +2,7 @@ import ModalContent from './ModalContent/ModalContent'
 import styles from './ImageModal.module.css'
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { getResizedImageUrl } from '~/lib/images'
 import type { Image } from '~/lib/types'
 
 interface ImageModalProps {
@@ -84,7 +85,7 @@ export default function ImageModal({ data }: ImageModalProps) {
                     href={`/images/${data.image_id}`}
                 >
                     <img
-                        src={data.url}
+                        src={getResizedImageUrl(data.url, 'thumbnail')}
                         alt={data.alt_text ?? ''}
                         width={data.width}
                         height={data.height}
@@ -102,7 +103,7 @@ export default function ImageModal({ data }: ImageModalProps) {
                     aria-label={`View ${data.title} in full size`}
                 >
                     <img
-                        src={data.url}
+                        src={getResizedImageUrl(data.url, 'thumbnail')}
                         alt={data.alt_text ?? ''}
                         width={data.width}
                         height={data.height}

--- a/src/components/ImageModal/ModalContent/ModalContent.tsx
+++ b/src/components/ImageModal/ModalContent/ModalContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import styles from '../ImageModal.module.css'
+import { getResizedImageUrl } from '~/lib/images'
 import type { Image } from '~/lib/types'
 
 interface ModalContentProps {
@@ -51,7 +52,7 @@ export default function ModalContent({ onClose, data }: ModalContentProps) {
                     aria-label={`View full details for ${data.title}`}
                 >
                     <img
-                        src={data.url}
+                        src={getResizedImageUrl(data.url, 'modal')}
                         alt={data.alt_text ?? ''}
                         width={data.width}
                         height={data.height}

--- a/src/components/ImagePage/ImagePage.tsx
+++ b/src/components/ImagePage/ImagePage.tsx
@@ -47,6 +47,8 @@ export default function ImagePage({ data }: ImagePageProps) {
 
     return (
         <div className={styles.imagecontainer}>
+            {/* Detail page intentionally renders the full-resolution
+                original (not a resized variant) — see issue #196. */}
             <img
                 title={data.title}
                 className={styles.image}

--- a/src/lib/images.test.ts
+++ b/src/lib/images.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { getResizedImageUrl, IMAGE_VARIANTS } from './images'
+
+describe('getResizedImageUrl', () => {
+    it('builds a thumbnail variant URL with the expected options', () => {
+        const result = getResizedImageUrl(
+            'https://pub.example.com/abc-123',
+            'thumbnail',
+        )
+        expect(result).toBe(
+            `https://pub.example.com/cdn-cgi/image/width=${IMAGE_VARIANTS.thumbnail.width},quality=${IMAGE_VARIANTS.thumbnail.quality},format=auto/abc-123`,
+        )
+    })
+
+    it('builds a modal variant URL with a larger width than thumbnail', () => {
+        const result = getResizedImageUrl(
+            'https://pub.example.com/abc-123',
+            'modal',
+        )
+        expect(result).toContain(`width=${IMAGE_VARIANTS.modal.width}`)
+        expect(IMAGE_VARIANTS.modal.width).toBeGreaterThan(
+            IMAGE_VARIANTS.thumbnail.width,
+        )
+    })
+
+    it('preserves the original key/filename unchanged', () => {
+        const result = getResizedImageUrl(
+            'https://pub.example.com/some-uuid-key-with-dashes',
+            'thumbnail',
+        )
+        expect(result.endsWith('/some-uuid-key-with-dashes')).toBe(true)
+    })
+
+    it('preserves the origin of the source URL', () => {
+        const result = getResizedImageUrl(
+            'https://images.loowis.co.uk/key-1',
+            'modal',
+        )
+        expect(
+            result.startsWith('https://images.loowis.co.uk/cdn-cgi/image/'),
+        ).toBe(true)
+    })
+
+    it('preserves query strings on the source URL', () => {
+        const result = getResizedImageUrl(
+            'https://pub.example.com/key-1?v=2',
+            'thumbnail',
+        )
+        expect(result.endsWith('/key-1?v=2')).toBe(true)
+    })
+
+    it('does not double-wrap a URL that is already resized', () => {
+        const already =
+            'https://pub.example.com/cdn-cgi/image/width=400,quality=75,format=auto/key-1'
+        const result = getResizedImageUrl(already, 'modal')
+        expect(result).toBe(already)
+    })
+
+    it('returns the input unchanged for a non-absolute/invalid URL', () => {
+        expect(getResizedImageUrl('not-a-url', 'thumbnail')).toBe('not-a-url')
+    })
+
+    it('returns an empty string for null/undefined input', () => {
+        expect(getResizedImageUrl(null, 'thumbnail')).toBe('')
+        expect(getResizedImageUrl(undefined, 'thumbnail')).toBe('')
+    })
+
+    it('returns the input unchanged when the URL has no path/key', () => {
+        expect(getResizedImageUrl('https://pub.example.com', 'thumbnail')).toBe(
+            'https://pub.example.com',
+        )
+        expect(
+            getResizedImageUrl('https://pub.example.com/', 'thumbnail'),
+        ).toBe('https://pub.example.com/')
+    })
+
+    it('produces different widths for thumbnail vs modal for the same source', () => {
+        const url = 'https://pub.example.com/key-1'
+        const thumb = getResizedImageUrl(url, 'thumbnail')
+        const modal = getResizedImageUrl(url, 'modal')
+        expect(thumb).not.toBe(modal)
+    })
+})

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,72 @@
+/**
+ * Builds resized image URLs on top of Cloudflare's Image Resizing feature,
+ * without introducing a separate upload/variant pipeline.
+ *
+ * Every image the app serves lives at `${R2_PUBLIC_URL}/<uuid-key>` (see
+ * `src/lib/r2.ts`). Cloudflare Image Resizing can transform any image on a
+ * zone on the fly via a special URL path: requesting
+ *   `${origin}/cdn-cgi/image/<options>/<path-to-image-on-this-zone>`
+ * has Cloudflare fetch the image at `<path>` on that same origin, resize it
+ * per `<options>`, cache the result at the edge, and return it — no change
+ * to how images are uploaded or stored.
+ *
+ * ASSUMPTION / RISK: this only works if Image Resizing is actually turned on
+ * for the zone that `R2_PUBLIC_URL` points at (Cloudflare dashboard > that
+ * zone > Speed > Optimization > Image Resizing). It's a paid feature on some
+ * plans and is off by default. This cannot be verified from this repo/CI —
+ * confirm it's enabled for the domain behind R2_PUBLIC_URL before relying on
+ * these URLs in production. If it's off, `/cdn-cgi/image/...` requests will
+ * fail (404 to visitors), so the callers below should not be the *only*
+ * place an original URL is derivable in a pinch.
+ */
+
+export type ImageVariant = 'thumbnail' | 'modal'
+
+interface VariantConfig {
+    width: number
+    quality: number
+}
+
+/**
+ * width: target render width for the largest common layout of that context
+ * (see the components that use each variant for the exact CSS sizing).
+ * quality: 75-80 is a standard "visually lossless enough" JPEG/WebP quality
+ * that meaningfully cuts file size vs. an uploaded original.
+ */
+export const IMAGE_VARIANTS: Record<ImageVariant, VariantConfig> = {
+    thumbnail: { width: 400, quality: 75 },
+    modal: { width: 1400, quality: 80 },
+}
+
+const RESIZE_PATH_PREFIX = '/cdn-cgi/image/'
+
+/**
+ * Returns a Cloudflare Image Resizing URL for `url` at the given variant.
+ * Falls back to returning `url` unchanged if it isn't a well-formed absolute
+ * URL, has no path (nothing to resize), or is already a resized URL.
+ */
+export function getResizedImageUrl(
+    url: string | null | undefined,
+    variant: ImageVariant,
+): string {
+    if (!url) return url ?? ''
+
+    let parsed: URL
+    try {
+        parsed = new URL(url)
+    } catch {
+        return url
+    }
+
+    if (parsed.pathname.startsWith(RESIZE_PATH_PREFIX)) {
+        return url
+    }
+
+    const key = parsed.pathname.replace(/^\/+/, '')
+    if (!key) return url
+
+    const { width, quality } = IMAGE_VARIANTS[variant]
+    const options = `width=${width},quality=${quality},format=auto`
+
+    return `${parsed.origin}${RESIZE_PATH_PREFIX}${options}/${key}${parsed.search}`
+}

--- a/src/routes/$.tsx
+++ b/src/routes/$.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import Layout from '~/components/Layout/Layout'
 import { getRandomVisibleImage } from '~/lib/server/images'
+import { getResizedImageUrl } from '~/lib/images'
 import styles from '~/styles/pages/four-oh-four.module.css'
 
 export const Route = createFileRoute('/$')({
@@ -23,7 +24,7 @@ function Custom404() {
                         <img
                             title={photo.title}
                             className={styles.image}
-                            src={photo.url}
+                            src={getResizedImageUrl(photo.url, 'modal')}
                             alt={photo.alt_text ?? ''}
                             width={photo.width}
                             height={photo.height}

--- a/src/routes/admin/edit/collection/index.tsx
+++ b/src/routes/admin/edit/collection/index.tsx
@@ -5,6 +5,7 @@ import {
     getAdminCollections,
     deleteCollection,
 } from '~/lib/server/admin-collections'
+import { getResizedImageUrl } from '~/lib/images'
 import styles from '~/styles/admin/edit-collection.module.css'
 
 export const Route = createFileRoute('/admin/edit/collection/')({
@@ -40,7 +41,10 @@ function EditCollections() {
                                 }}
                             >
                                 <img
-                                    src={collection.cover_url}
+                                    src={getResizedImageUrl(
+                                        collection.cover_url,
+                                        'thumbnail',
+                                    )}
                                     width={collection.width}
                                     height={collection.height}
                                     className={styles.image}

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
 import Layout from '~/components/Layout/Layout'
 import { getAdminImages, deleteImage } from '~/lib/server/admin-images'
+import { getResizedImageUrl } from '~/lib/images'
 import styles from '~/styles/pages/dashboard.module.css'
 
 export const Route = createFileRoute('/admin/')({
@@ -43,7 +44,10 @@ function Dashboard() {
                                 }}
                             >
                                 <img
-                                    src={image.url}
+                                    src={getResizedImageUrl(
+                                        image.url,
+                                        'thumbnail',
+                                    )}
                                     alt={image.alt_text ?? ''}
                                     width={image.width}
                                     height={image.height}


### PR DESCRIPTION
## Summary

Fixes #196. Every page currently points at the same R2 original — a thumbnail in the gallery grid downloads the exact same bytes as the full detail-page image. This adds a small helper that builds a [Cloudflare Image Resizing](https://developers.cloudflare.com/images/transform-images/) URL on top of the existing `R2_PUBLIC_URL`, with no new upload pipeline, no new storage, and no schema change.

- `src/lib/images.ts` — `getResizedImageUrl(url, variant)` rewrites `${R2_PUBLIC_URL}/<key>` to `${R2_PUBLIC_URL}/cdn-cgi/image/width=W,quality=Q,format=auto/<key>` for a given variant (`thumbnail`: width 400/quality 75, `modal`: width 1400/quality 80). It's a pure string-building function with no server-only imports, so it's safe to use from client-rendered components (unlike `src/lib/r2.ts`, which imports `cloudflare:workers` at module scope).
- Applied to every thumbnail/preview rendering context, not just the two files named in the issue:
  - `ImageModal` / `ModalContent` (gallery grid tile + popup preview)
  - `CollectionPreview` (collection cover thumbnails)
  - Admin dashboard grid and admin edit-collection grid
  - `CollectionForm`'s image-picker thumbnails
  - The random photo shown on the 404 page
- **Left as the untouched original**: `ImagePage` (the dedicated image detail page — per the issue, this should keep serving full resolution), and `og:image`/JSON-LD metadata (social scrapers/crawlers generally want the highest-quality image, not a client-viewport-sized one).
- `src/lib/images.test.ts` — unit tests for the helper: correct width per variant, key/filename preserved, query string preserved, origin preserved, no double-wrapping an already-resized URL, and graceful fallback to the original string for null/undefined/invalid/pathless input.

## Assumption / risk — please confirm before merging

**This entire approach depends on Cloudflare Image Resizing being enabled for the zone that `R2_PUBLIC_URL` points at** (Cloudflare dashboard → that zone → Speed → Optimization → Image Resizing). It's a paid feature on some plans and is off by default; I can't verify from this repo or CI whether it's turned on for that domain today.

If it's off, every `/cdn-cgi/image/...` request will fail (visitors would see broken images), so please enable it (or confirm it's already enabled) for the zone in front of `R2_PUBLIC_URL` before merging/deploying this. If Image Resizing turns out not to be available on the current plan/zone, the fix is to revert to plain `url` in the affected components — the helper is isolated to `src/lib/images.ts` and its ~10 call sites, so that's a small, contained change either way.

## Test plan

- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm test` (47 tests incl. 10 new ones in `images.test.ts`)
- [x] `npm run build` (vite build + `tsc --noEmit`)
- [x] `npm run test:e2e` (26 Playwright tests)
- [ ] Manually verify a resized URL actually resizes/serves correctly against the real `pictures.loowis.co.uk`/R2 zone once Image Resizing is confirmed enabled (not possible to test locally/in CI)