### PR TITLE
Set long Cache-Control on R2 image uploads

### DIFF
--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -64,7 +64,12 @@ describe('uploadToR2', () => {
         expect(mockPut).toHaveBeenCalledWith(
             'test-uuid-1234',
             expect.any(Buffer),
-            { httpMetadata: { contentType: 'image/jpeg' } },
+            {
+                httpMetadata: {
+                    contentType: 'image/jpeg',
+                    cacheControl: 'public, max-age=31536000, immutable',
+                },
+            },
         )
     })
 

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -26,7 +26,10 @@ export async function uploadToR2(base64Data: string) {
     const key = uuidv4()
 
     await env.R2_BUCKET.put(key, buffer, {
-        httpMetadata: { contentType: mimeType },
+        httpMetadata: {
+            contentType: mimeType,
+            cacheControl: 'public, max-age=31536000, immutable',
+        },
     })
 
     return { url: `${process.env.R2_PUBLIC_URL}/${key}` }


### PR DESCRIPTION
## Summary
- Fixes #207 — Lighthouse's `cache-insight` audit flagged every images.loowis.co.uk/* request as having a 0ms cache TTL, forcing repeat visits to re-download the same multi-MB image originals.
- Image keys are UUIDs, so uploaded objects are already content-addressed and immutable — safe to cache aggressively.
- `uploadToR2` in `src/lib/r2.ts` now passes `cacheControl: 'public, max-age=31536000, immutable'` alongside `contentType` in the R2 `put()` httpMetadata, which R2's public/custom-domain serving honors on GET responses.
- Updated `src/lib/r2.test.ts` to assert the `put` call includes the new `cacheControl` metadata.

## Known limitation
This only affects **newly uploaded** images going forward. Objects already sitting in R2 keep whatever httpMetadata they were uploaded with and will **not** retroactively pick up the new Cache-Control header. Backfilling existing objects (e.g. a script that re-`put`s each object with updated metadata, or copies objects over themselves) would need to be a separate piece of work.

## Test plan
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm test` (all unit tests pass, including updated `r2.test.ts`)
- [x] `npm run build` (vite build + `tsc --noEmit`)