### PR TITLE
Render only the active format's gallery on the homepage

### DIFF
--- a/src/lib/search-params.test.ts
+++ b/src/lib/search-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateImageSearch } from './search-params'
+import { validateImageSearch, validateHomeSearch } from './search-params'
 
 describe('validateImageSearch', () => {
     it('returns defaults for empty search', () => {
@@ -46,5 +46,23 @@ describe('validateImageSearch', () => {
 
     it('defaults invalid filter to all', () => {
         expect(validateImageSearch({ filter: 'invalid' }).filter).toBe('all')
+    })
+})
+
+describe('validateHomeSearch', () => {
+    it('defaults to film for empty search', () => {
+        expect(validateHomeSearch({})).toEqual({ format: 'film' })
+    })
+
+    it('parses a valid format', () => {
+        expect(validateHomeSearch({ format: 'digital' })).toEqual({
+            format: 'digital',
+        })
+    })
+
+    it('defaults invalid format to film', () => {
+        expect(validateHomeSearch({ format: 'invalid' })).toEqual({
+            format: 'film',
+        })
     })
 })

--- a/src/lib/search-params.ts
+++ b/src/lib/search-params.ts
@@ -26,3 +26,20 @@ export function validateImageSearch(
         : 'all'
     return { page, sort, filter }
 }
+
+export type HomeFormat = 'film' | 'digital'
+
+const VALID_HOME_FORMATS: HomeFormat[] = ['film', 'digital']
+
+export interface HomeSearchParams {
+    format: HomeFormat
+}
+
+export function validateHomeSearch(
+    search: Record<string, unknown>,
+): HomeSearchParams {
+    const format = VALID_HOME_FORMATS.includes(search.format as HomeFormat)
+        ? (search.format as HomeFormat)
+        : 'film'
+    return { format }
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { BASE_URL } from '~/lib/constants'
-import { useState } from 'react'
+import { useMemo } from 'react'
 import Layout from '~/components/Layout/Layout'
 import ImageModal from '~/components/ImageModal/ImageModal'
 import { getFeaturedImages } from '~/lib/server/images'
+import { validateHomeSearch } from '~/lib/search-params'
 import styles from '~/styles/pages/index.module.css'
 
 export const Route = createFileRoute('/')({
+    validateSearch: validateHomeSearch,
     loader: () => getFeaturedImages(),
     head: ({ match }) => ({
         meta: [{ title: 'Loowis Photography' }],
@@ -17,11 +19,13 @@ export const Route = createFileRoute('/')({
 
 function Home() {
     const data = Route.useLoaderData()
-    const [dFeatured] = useState(data.filter((photo) => photo.digital === true))
-    const [aFeatured] = useState(
-        data.filter((photo) => photo.digital === false),
+    const { format } = Route.useSearch()
+    const navigate = useNavigate({ from: Route.fullPath })
+
+    const images = useMemo(
+        () => data.filter((photo) => photo.digital === (format === 'digital')),
+        [data, format],
     )
-    const [format, setFormat] = useState('film')
 
     return (
         <Layout>
@@ -30,7 +34,9 @@ function Home() {
                     <div className={styles.formatSelection}>
                         <button
                             type="button"
-                            onClick={() => setFormat('film')}
+                            onClick={() =>
+                                navigate({ search: { format: 'film' } })
+                            }
                             className={
                                 format === 'film'
                                     ? styles.formatTitleActive
@@ -41,7 +47,9 @@ function Home() {
                         </button>
                         <button
                             type="button"
-                            onClick={() => setFormat('digital')}
+                            onClick={() =>
+                                navigate({ search: { format: 'digital' } })
+                            }
                             className={
                                 format === 'digital'
                                     ? styles.formatTitleActive
@@ -51,25 +59,8 @@ function Home() {
                             Digital
                         </button>
                     </div>
-                    <div
-                        className={
-                            format === 'digital'
-                                ? styles.digitalShow
-                                : styles.digitalHide
-                        }
-                    >
-                        {dFeatured.map((d) => (
-                            <ImageModal data={d} key={d.image_id} />
-                        ))}
-                    </div>
-                    <div
-                        className={
-                            format === 'film'
-                                ? styles.filmShow
-                                : styles.filmHide
-                        }
-                    >
-                        {aFeatured.map((d) => (
+                    <div className={styles.gallery}>
+                        {images.map((d) => (
                             <ImageModal data={d} key={d.image_id} />
                         ))}
                     </div>

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -45,25 +45,11 @@
     margin: 0.5rem;
 }
 
-.digitalShow {
+.gallery {
     display: block;
     line-break: strict;
     columns: 3;
     margin: 1rem;
-}
-
-.digitalHide {
-    display: none;
-}
-
-.filmShow {
-    display: block;
-    columns: 3;
-    margin: 1rem;
-}
-
-.filmHide {
-    display: none;
 }
 
 @media only screen and (max-width: 1320px) {
@@ -71,11 +57,7 @@
         width: 100%;
     }
 
-    .digitalShow {
-        columns: 1;
-    }
-
-    .filmShow {
+    .gallery {
         columns: 1;
     }
 }


### PR DESCRIPTION
## Summary
- The Film/Digital toggle on the homepage rendered both full image sets into the DOM and CSS-hid the inactive one — same wasted-load pattern as the ImageModal double-fetch fix in #203, but on the highest-traffic page.
- Now only the active format's images render, via a `useMemo` filter over the loader data.
- The toggle state is now reflected in the URL (`?format=film|digital`) using a new `validateHomeSearch` in `src/lib/search-params.ts`, so it's shareable and back-button-able.

## Test plan
- [x] `npx vitest run src/lib/search-params.test.ts` — new `validateHomeSearch` tests pass
- [x] `npm run build` (vite build + tsc --noEmit) passes
- [x] lint / prettier clean

Fixes #197