### PR TITLE
Add CSP, X-Frame-Options, and Referrer-Policy headers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,53 @@
+import {
+    createStartHandler,
+    defaultStreamHandler,
+} from '@tanstack/react-start/server'
+
+// Third-party origins the app actually loads, kept in sync with:
+// - src/routes/image-map.tsx / src/components/ImagePage / src/components/PhotoForm
+//   (Leaflet map tiles + marker icons)
+// - src/lib/r2.ts (R2_PUBLIC_URL, served publicly as images.loowis.co.uk)
+// - src/routes/api/auth/$.ts (Auth.js GitHub OAuth sign-in form submission)
+const CSP = [
+    "default-src 'self'",
+    // TanStack Start injects the router hydration payload as an inline
+    // <script>, and Auth.js's built-in sign-in page ships inline <style>.
+    // There's no nonce/hash plumbed through yet, so allow 'unsafe-inline'
+    // rather than break hydration/auth.
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    // authjs.dev serves the GitHub provider icon on Auth.js's built-in
+    // sign-in page.
+    "img-src 'self' data: https://images.loowis.co.uk https://unpkg.com https://tile.openstreetmap.org https://authjs.dev",
+    "font-src 'self'",
+    "connect-src 'self'",
+    // Auth.js's sign-in page submits a form that redirects to GitHub's OAuth
+    // authorize endpoint.
+    "form-action 'self' https://github.com",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "object-src 'none'",
+].join('; ')
+
+const startFetch = createStartHandler(defaultStreamHandler)
+
+function withSecurityHeaders(response: Response): Response {
+    const headers = new Headers(response.headers)
+    headers.set('Content-Security-Policy', CSP)
+    headers.set('X-Frame-Options', 'DENY')
+    headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    })
+}
+
+export default {
+    fetch: async (
+        ...args: Parameters<typeof startFetch>
+    ): Promise<Response> => {
+        const response = await startFetch(...args)
+        return withSecurityHeaders(response)
+    },
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,26 +3,18 @@ import {
     defaultStreamHandler,
 } from '@tanstack/react-start/server'
 
-// Third-party origins the app actually loads, kept in sync with:
-// - src/routes/image-map.tsx / src/components/ImagePage / src/components/PhotoForm
-//   (Leaflet map tiles + marker icons)
-// - src/lib/r2.ts (R2_PUBLIC_URL, served publicly as images.loowis.co.uk)
-// - src/routes/api/auth/$.ts (Auth.js GitHub OAuth sign-in form submission)
+// Origins here must stay in sync with what image-map/ImagePage/PhotoForm
+// (Leaflet), r2.ts (R2_PUBLIC_URL), and Auth.js's sign-in page actually load.
 const CSP = [
     "default-src 'self'",
-    // TanStack Start injects the router hydration payload as an inline
-    // <script>, and Auth.js's built-in sign-in page ships inline <style>.
-    // There's no nonce/hash plumbed through yet, so allow 'unsafe-inline'
-    // rather than break hydration/auth.
+    // unsafe-inline: TanStack Start's hydration script and Auth.js's
+    // sign-in page styles are both inline, with no nonce/hash plumbed in yet.
     "script-src 'self' 'unsafe-inline'",
     "style-src 'self' 'unsafe-inline'",
-    // authjs.dev serves the GitHub provider icon on Auth.js's built-in
-    // sign-in page.
     "img-src 'self' data: https://images.loowis.co.uk https://unpkg.com https://tile.openstreetmap.org https://authjs.dev",
     "font-src 'self'",
     "connect-src 'self'",
-    // Auth.js's sign-in page submits a form that redirects to GitHub's OAuth
-    // authorize endpoint.
+    // Auth.js's sign-in page submits a form to GitHub's OAuth authorize endpoint.
     "form-action 'self' https://github.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
     "name": "photography-website",
     "compatibility_date": "2025-04-01",
     "compatibility_flags": ["nodejs_compat"],
-    "main": "@tanstack/react-start/server-entry",
+    "main": "src/server.ts",
     "observability": {
         "enabled": true,
     },


### PR DESCRIPTION
## Why

This is a single-admin portfolio site, so the risk this closes is narrow, but each header is defending against a specific, cheap-to-prevent class of attack:

- **CSP**: without it, any successful XSS (e.g. a compromised third-party script, or a future feature that renders less-trusted content) can exfiltrate data, load arbitrary scripts, or hijack the page with no client-side resistance. The policy here is scoped tightly to the origins the app actually loads — R2 images, Leaflet tiles/unpkg, Auth.js's GitHub sign-in assets/redirect — everything else is blocked by default (`default-src 'self'`, `object-src 'none'`).
- **X-Frame-Options: DENY**: prevents the site being framed on another origin for clickjacking (e.g. an invisible iframe over the admin login/delete buttons tricking a click).
- **Referrer-Policy**: `strict-origin-when-cross-origin` stops the full URL path (which could include admin-area paths or query strings) leaking to third-party origins via the `Referer` header on outbound requests/link clicks.

None of these require any behavior change from a visitor — they're purely defense-in-depth. Lighthouse/security-header scanners also flag their absence, so this closes that out too.

## Summary
- No CSP, `X-Frame-Options`/`frame-ancestors`, or `Referrer-Policy` was set anywhere in the Worker response.
- Adds `src/server.ts` — a custom server entry (replacing the default `@tanstack/react-start/server-entry` via `wrangler.jsonc`'s `main`) that wraps every response with:
  - `Content-Security-Policy`, scoped to the origins the app actually loads (R2 image host, Leaflet tiles/unpkg, Auth.js's GitHub sign-in page assets and OAuth redirect)
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: strict-origin-when-cross-origin`

## Test plan
- [x] Checked response headers directly (`curl -D-`) on the homepage — all three headers present with the expected values
- [x] Ran a headless-browser console-error check across `/`, `/image-map`, `/all-images`, `/admin`, `/collections`, `/search/:query` — zero CSP violations (one was found and fixed along the way: `authjs.dev` needed adding to `img-src` for the GitHub sign-in icon)
- [x] `npm run build` (vite build + tsc --noEmit) passes
- [x] Full admin e2e suite (`npx playwright test e2e/admin.spec.ts`) passes against the new server entry, confirming `E2E_TEST_MODE` auth bypass still works
- [x] lint / prettier clean

Fixes #199
