### PR TITLE
Prevent gallery cards from splitting across column breaks

### DIFF
--- a/src/components/CollectionPreview/CollectionPreview.module.css
+++ b/src/components/CollectionPreview/CollectionPreview.module.css
@@ -5,6 +5,8 @@
     padding: 2.5%;
     text-align: center;
     position: relative;
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
 }
 
 .collectionpreview {

--- a/src/components/ImageModal/ImageModal.module.css
+++ b/src/components/ImageModal/ImageModal.module.css
@@ -4,6 +4,8 @@
     box-shadow: 0.25rem 0.25rem var(--color-black);
     margin: 0 1rem 1rem;
     transition: 0.3s;
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
 }
 
 .imageContainer:hover {


### PR DESCRIPTION
## Summary
On every \`columns: 3\` masonry page (homepage Film/Digital gallery, \`/all-images\`, \`/collections\`), a card that falls right at the column-balance boundary could be fragmented by the browser's CSS multi-column engine: an empty, background-colored "ghost" of the card renders at the bottom of one column, and the same card's real content (image + title) renders again at the top of the next column.

This is a pre-existing bug, unrelated to #196/#207/#199/#200 — found while visually verifying #196's live preview and confirmed present on production \`main\` via screenshot. Not caught by automated \`getBoundingClientRect()\`-based checks, since the browser paints this as two visual fragments of the *same* DOM node rather than two separate elements — it only shows up in an actual rendered screenshot at a specific viewport height, and I couldn't get Playwright's \`fullPage\` screenshot mode to reproduce it in Chromium, Firefox, or WebKit (it resizes the viewport to the full content height first, which changes the column-balance math entirely vs. a real fixed-height viewport).

**Root cause**: none of the masonry item classes (\`.imageContainer\` in ImageModal, \`.collectioncontainer\` in CollectionPreview) set \`break-inside: avoid\`, so CSS fragmentation was free to split a card's box across a column boundary instead of pushing the whole card to the next column.

**Fix**: add \`break-inside: avoid\` (+ \`-webkit-column-break-inside: avoid\` for older Safari) to both masonry item wrapper classes.

## Test plan
- [x] \`npx vitest run\` — all 48 tests pass
- [x] \`npm run build\` (vite build + tsc --noEmit) passes
- [x] lint / prettier clean
- [ ] Please confirm on your end that this resolves what you were seeing — I wasn't able to reliably reproduce the split in an automated screenshot to verify directly, so I'd appreciate a manual check against the branch preview once it deploys.

Fixes #219